### PR TITLE
feat(vivo): 添加尝鲜公测内测通道查询功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -424,3 +424,5 @@ obj/
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/java,linux,macos,kotlin,android,windows,composer,jetbrains,androidstudio,visualstudiocode,xcode
+
+.idea

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -31,12 +31,16 @@ android {
     namespace = ProjectConfig.NAMESPACE
     compileSdk = ProjectConfig.Android.COMPILE_SDK
     buildToolsVersion = ProjectConfig.Android.BUILD_TOOLS_VERSION
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         applicationId = ProjectConfig.PACKAGE_NAME
         versionCode = getGitVersionCode()
         versionName = ProjectConfig.VERSION_NAME
         targetSdk = ProjectConfig.Android.TARGET_SDK
         minSdk = ProjectConfig.Android.MIN_SDK
+        buildConfigField("String", "APP_VERSION_NAME", "\"${ProjectConfig.VERSION_NAME}\"")
     }
     val properties = Properties()
     runCatching { properties.load(project.rootProject.file("local.properties").inputStream()) }

--- a/app/android/proguard-rules-android.pro
+++ b/app/android/proguard-rules-android.pro
@@ -11,6 +11,13 @@
 }
 -keep class com.mytiantian.updater.** { *; }
 
+# Vivo SecKey SDK (libvivoseckey.so JNI engine)
+# 必须原样保留，否则 R8 混淆/裁剪后 SDKCipherNative.init() 失败，
+# UI 会一直卡在"正在初始化加密引擎"。
+-keep class com.vivo.seckeysdk.** { *; }
+-keep class com.vivo.seckeysdk.utils.** { *; }
+-dontwarn com.vivo.seckeysdk.**
+
 # OkHttp
 -dontwarn okhttp3.**
 -dontwarn okio.**

--- a/app/android/src/main/kotlin/com/mytiantian/updater/AndroidAppContext.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/AndroidAppContext.kt
@@ -2,6 +2,7 @@ package com.mytiantian.updater
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.PackageManager
 
 @SuppressLint("StaticFieldLeak")
 object AndroidAppContext {
@@ -14,4 +15,37 @@ object AndroidAppContext {
     fun getApplicationContext(): Context? {
         return context
     }
+
+    /** 应用版本名，例如 "1.3.0"，回退到 BuildConfig.APP_VERSION_NAME 以防包管理器读取失败 */
+    val versionName: String
+        get() = runCatching {
+            val ctx = context ?: return@runCatching BuildConfig.APP_VERSION_NAME
+            val pm = ctx.packageManager
+            val info = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                pm.getPackageInfo(ctx.packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getPackageInfo(ctx.packageName, 0)
+            }
+            info.versionName ?: BuildConfig.APP_VERSION_NAME
+        }.getOrDefault(BuildConfig.APP_VERSION_NAME)
+
+    /** 应用版本号 (versionCode)，例如 42，回退到 0 以防包管理器读取失败 */
+    val versionCode: Long
+        get() = runCatching {
+            val ctx = context ?: return@runCatching 0L
+            val pm = ctx.packageManager
+            val info = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                pm.getPackageInfo(ctx.packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getPackageInfo(ctx.packageName, 0)
+            }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                info.longVersionCode
+            } else {
+                @Suppress("DEPRECATION")
+                info.versionCode.toLong()
+            }
+        }.getOrDefault(0L)
 }

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
@@ -194,6 +194,7 @@ fun VivoApp(viewModel: VivoOtaViewModel = viewModel()) {
 
                 item { VersionInputCard(state, viewModel) }
                 item { SnInputCard(state, viewModel) }
+                item { ChannelCard(state, viewModel) }
                 item { PackageTypeCard(state, viewModel) }
 
                 item { QueryButton(state, viewModel) }
@@ -451,12 +452,45 @@ private fun SnInputCard(state: VivoOtaUiState, viewModel: VivoOtaViewModel) {
 private fun PackageTypeCard(state: VivoOtaUiState, viewModel: VivoOtaViewModel) {
     val fullPkg = stringResource(R.string.pkg_full)
     val incrementalPkg = stringResource(R.string.pkg_incremental)
+    // 尝鲜 / 公测 / 内测通道仅允许增量包
+    val packageLocked = state.queryChannel != "NORMAL"
+    val lockHint = stringResource(R.string.pkg_locked_incremental)
     Card(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
         OverlayDropdownPreference(
             title = stringResource(R.string.label_package_type),
             items = listOf(fullPkg, incrementalPkg),
             selectedIndex = if (state.isFullPackage) 0 else 1,
-            onSelectedIndexChange = { viewModel.togglePackageType() },
+            onSelectedIndexChange = { if (!packageLocked) viewModel.togglePackageType() },
+            enabled = !packageLocked,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (packageLocked) {
+            Text(
+                text = lockHint,
+                fontSize = 12.sp,
+                color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChannelCard(state: VivoOtaUiState, viewModel: VivoOtaViewModel) {
+    val channels = listOf(
+        stringResource(R.string.channel_normal),
+        stringResource(R.string.channel_trial),
+        stringResource(R.string.channel_beta),
+        stringResource(R.string.channel_alpha)
+    )
+    val channelValues = listOf("NORMAL", "TRIAL", "BETA", "ALPHA")
+    val selectedIndex = channelValues.indexOf(state.queryChannel).takeIf { it >= 0 } ?: 0
+    Card(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
+        OverlayDropdownPreference(
+            title = stringResource(R.string.label_query_channel),
+            items = channels,
+            selectedIndex = selectedIndex,
+            onSelectedIndexChange = { viewModel.updateQueryChannel(channelValues[it]) },
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -504,6 +538,14 @@ private fun ResultCard(
     val haptic = LocalHapticFeedback.current
     val copiedMsg = stringResource(R.string.copied)
     val firmwareTypeStr = stringResource(if (isFullPackage) R.string.pkg_full else R.string.pkg_incremental)
+    val channelStr = stringResource(
+        when (result.channel) {
+            "TRIAL" -> R.string.channel_trial
+            "BETA" -> R.string.channel_beta
+            "ALPHA" -> R.string.channel_alpha
+            else -> R.string.channel_normal
+        }
+    )
 
     fun copyToClipboard(label: String, text: String) {
         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -536,6 +578,7 @@ private fun ResultCard(
             }
             Text(stringResource(R.string.label_android_version) + ": $androidVersion", color = MiuixTheme.colorScheme.onSurfaceVariantSummary)
             Text(stringResource(R.string.label_package_type) + ": $firmwareTypeStr", color = MiuixTheme.colorScheme.onSurfaceVariantSummary)
+            Text(stringResource(R.string.label_query_channel) + ": $channelStr", color = MiuixTheme.colorScheme.onSurfaceVariantSummary)
             if (result.securityPatch.isNotEmpty() && result.securityPatch != "(Not found)") {
                 Text(
                     stringResource(R.string.security_patch, result.securityPatch),
@@ -729,6 +772,17 @@ private fun HistoryEntrySelectionRow(
                 color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
                 fontSize = 13.sp
             )
+            if (entry.channel != "NORMAL") {
+                val ch = stringResource(
+                    when (entry.channel) {
+                        "TRIAL" -> R.string.channel_trial
+                        "BETA" -> R.string.channel_beta
+                        "ALPHA" -> R.string.channel_alpha
+                        else -> R.string.channel_normal
+                    }
+                )
+                Text(ch, color = MiuixTheme.colorScheme.primary, fontSize = 12.sp)
+            }
             if (entry.fileSize.isNotEmpty()) {
                 Text(
                     stringResource(R.string.history_size, entry.fileSize),
@@ -801,6 +855,17 @@ private fun SwipeToDeleteHistoryEntry(
                 color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
                 fontSize = 13.sp
             )
+            if (entry.channel != "NORMAL") {
+                val ch = stringResource(
+                    when (entry.channel) {
+                        "TRIAL" -> R.string.channel_trial
+                        "BETA" -> R.string.channel_beta
+                        "ALPHA" -> R.string.channel_alpha
+                        else -> R.string.channel_normal
+                    }
+                )
+                Text(ch, color = MiuixTheme.colorScheme.primary, fontSize = 12.sp)
+            }
             if (entry.fileSize.isNotEmpty()) {
                 Text(
                     stringResource(R.string.history_size, entry.fileSize),

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
@@ -1002,6 +1002,23 @@ private fun AboutDialog(onDismiss: () -> Unit) {
                     )
                     Spacer(modifier = Modifier.height(6.dp))
 
+                    Text("ℳℓ矜ℳℓ持", fontSize = 13.sp)
+                    Text(
+                        text = "Coolapk @ℳℓ矜ℳℓ持",
+                        color = MiuixTheme.colorScheme.primary,
+                        fontSize = 12.sp,
+                        modifier = Modifier.combinedClickable(
+                            onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.coolapk.com/u/922815"))) },
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                val cb = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                cb.setPrimaryClip(ClipData.newPlainText("url", "https://www.coolapk.com/u/922815"))
+                                Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                            }
+                        )
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+
                     Text(stringResource(R.string.about_reference), fontSize = 13.sp, fontWeight = FontWeight.Bold)
                     Text(
                         text = "YuKongA / Updater-KMP",

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoApp.kt
@@ -908,7 +908,13 @@ private fun AboutDialog(onDismiss: () -> Unit) {
                     )
                     Spacer(modifier = Modifier.height(2.dp))
                     Text(stringResource(R.string.app_name), fontSize = 17.sp, fontWeight = FontWeight.Bold)
-                    Text("v1.3.0", fontSize = 13.sp, color = MiuixTheme.colorScheme.onSurfaceVariantSummary)
+                    val appVersion = "v" + com.mytiantian.updater.AndroidAppContext.versionName
+                    val appVersionCode = com.mytiantian.updater.AndroidAppContext.versionCode
+                    Text(
+                        text = "$appVersion ($appVersionCode)",
+                        fontSize = 13.sp,
+                        color = MiuixTheme.colorScheme.onSurfaceVariantSummary
+                    )
                     Spacer(modifier = Modifier.height(12.dp))
                     HorizontalDivider()
                     Spacer(modifier = Modifier.height(10.dp))

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoModels.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoModels.kt
@@ -10,6 +10,7 @@ data class VivoOtaResult(
     val securityPatch: String = "",
     val updateDate: String = "",
     val md5: String = "",
+    val channel: String = "NORMAL",
     val rawResponse: String = ""
 )
 
@@ -20,22 +21,24 @@ data class QueryHistoryEntry(
     val swVersion: String,
     val resultVersion: String,
     val fileSize: String,
-    val downloadUrl: String
+    val downloadUrl: String,
+    val channel: String = "NORMAL"
 )
 
 data class VivoOtaUiState(
-    val selectedSeries: String = "",
+    val selectedSeries: String = "X 系列",
     val selectedModelIndex: Int = 0,
     val selectedModel: String = "",
     val selectedCodename: String = "",
     val selectedModelSwVer: String = "",
     val deviceType: String = "phone",
-    val softwareVersion: String = "",
-    val androidVersion: Int = 16,
+    val softwareVersion: String = "15.0.33.7.W10",
+    val androidVersion: Int = 15,
     val isCustomAndroidVersion: Boolean = false,
     val customAndroidVersion: String = "",
     val sn: String = "A0000000000000A",
     val isFullPackage: Boolean = true,
+    val queryChannel: String = "NORMAL",
     val isLoading: Boolean = false,
     val result: VivoOtaResult? = null,
     val error: String? = null,

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoOtaClient.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoOtaClient.kt
@@ -26,6 +26,16 @@ class VivoOtaClient(private val context: Context) {
         private const val TOKEN_NATIVE = "jnisgmain_v2@com.bbk.updater"
         private const val OTA_URL = "https://sysupgrade.vivo.com.cn/vgc/v2/getVgcAndPatch.do"
         private const val REDIR_URL = "https://sysupgrade.vivo.com.cn/pk/redirPost.do"
+        private const val TASTE_URL = "https://sysupgrade.vivo.com.cn/upgrade/trial/getTastePk"
+        private const val BETA_URL = "https://sysupgrade.vivo.com.cn/beta/query"
+        private const val ALPHA_URL = "https://sysupgrade.vivo.com.cn/alpha/getAlphaState"
+    }
+
+    enum class QueryChannel(val value: String) {
+        NORMAL("NORMAL"),
+        TRIAL("TRIAL"),
+        BETA("BETA"),
+        ALPHA("ALPHA")
     }
 
     fun initCrypto(): Boolean {
@@ -40,7 +50,8 @@ class VivoOtaClient(private val context: Context) {
         androidVersion: Int,
         isPhone: Boolean,
         isFull: Boolean,
-        sn: String = "A0000000000000A"
+        sn: String = "A0000000000000A",
+        channel: QueryChannel = QueryChannel.NORMAL
     ): VivoOtaResult {
         val hwVer = codename + "MA"
         val fullSwVersion = if (swVersion.contains(".W")) "$swVersion.V000L1" else swVersion
@@ -122,15 +133,70 @@ class VivoOtaClient(private val context: Context) {
             p["radiotype"] = "A"
         }
 
-        val rawParams = joinParams(p)
-        Log.d(TAG, "Request params: $rawParams")
+        // 尝鲜/公测/内测通道：去掉正式版专属字段，改用 taste 字段集
+        val isTaste = channel != QueryChannel.NORMAL
+        if (isTaste) {
+            p.remove("isMan")
+            p.remove("protocalversion")
+            p.remove("checkTrige")
+            p.remove("isstlifeover")
+            p["trigger"] = "verfy"
+            p["isSupportVgcTaste"] = 1
+            p["isSupportShowNote"] = 1
+            p["hwFingerprint"] = ""
+        }
 
-        val updateResponse = sendFreshEncryptedRequest(rawParams)
+        val rawParams = joinParams(p)
+        Log.d(TAG, "Request params (channel=${channel.value}): $rawParams")
+
+        // 公测/内测先查询报名状态（beta/query 或 alpha/getAlphaState）
+        if (channel == QueryChannel.BETA || channel == QueryChannel.ALPHA) {
+            val betaParams = buildBetaBaseParams(
+                model = codename,
+                hwVer = hwVer,
+                swVer = swVersion,
+                cy = "CN-ZH",
+                cu = "N",
+                dType = if (isPhone) "phone" else "tablet",
+                vgcCu = "V000",
+                imei = "000000000000000",
+                snp = sn,
+                isPhone = isPhone,
+                romVer = fullSwVersion
+            ) + if (channel == QueryChannel.BETA) "&manual=1&push=0" else "&manual=1"
+            val stateJson = if (channel == QueryChannel.BETA) {
+                sendBetaRequest(betaParams)
+            } else {
+                sendAlphaRequest(betaParams)
+            }
+            Log.d(TAG, "${channel.value} state: $stateJson")
+        }
+
+        val updateResponse = if (isTaste) sendTasteRequest(rawParams) else sendFreshEncryptedRequest(rawParams)
         if (updateResponse.startsWith("[Error]")) {
             throw RuntimeException(updateResponse)
         }
 
-        return parseResult(updateResponse, isPhone, modelSwVer, codename, swVersion)
+        return parseResult(updateResponse, isPhone, modelSwVer, codename, swVersion, channel)
+    }
+
+    /** 公测/内测共用参数集，与 PC 版 buildBetaBaseParams 对应。 */
+    private fun buildBetaBaseParams(
+        model: String, hwVer: String, swVer: String,
+        cy: String, cu: String, dType: String, vgcCu: String,
+        imei: String, snp: String, isPhone: Boolean, romVer: String
+    ): String {
+        val sb = StringBuilder()
+        sb.append("model=").append(model)
+        sb.append("&hwVer=").append(hwVer)
+        sb.append("&swVer=").append(swVer)
+        sb.append("&cy=").append(cy)
+        sb.append("&cu=").append(cu)
+        sb.append("&dType=").append(dType)
+        sb.append("&vgcCu=").append(vgcCu)
+        sb.append(if (isPhone) "&imei=$imei" else "&snp=$snp")
+        sb.append("&romVer=").append(romVer)
+        return sb.toString()
     }
 
     private fun parseResult(
@@ -138,7 +204,8 @@ class VivoOtaClient(private val context: Context) {
         isPhone: Boolean,
         modelSwVer: String,
         codename: String,
-        swVersion: String
+        swVersion: String,
+        channel: QueryChannel = QueryChannel.NORMAL
     ): VivoOtaResult {
         Log.d(TAG, "Raw OTA response: $updateResponse")
 
@@ -194,6 +261,7 @@ class VivoOtaClient(private val context: Context) {
             securityPatch = securityPatch,
             updateDate = updateDate,
             md5 = md5,
+            channel = channel.value,
             rawResponse = updateResponse
         )
     }
@@ -341,6 +409,39 @@ class VivoOtaClient(private val context: Context) {
     private fun requestRedirPost(params: String): String {
         val jvqParam = encryptToJvq(params)
         val response = httpPost(REDIR_URL, "jvq_param=$jvqParam")
+        return if (!response.startsWith("ACw") && !response.startsWith("ACo")) {
+            "[Error] $response"
+        } else {
+            decryptResponse(response)
+        }
+    }
+
+    // 尝鲜/公测/内测通道的尝鲜包查询（getTastePk），与 PC 版 sendTasteRequest 对应
+    private fun sendTasteRequest(plaintext: String): String {
+        val jvqParam = encryptToJvq(plaintext)
+        val response = httpPost(TASTE_URL, "jvq_param=$jvqParam")
+        return if (!response.startsWith("ACw") && !response.startsWith("ACo")) {
+            "[Error] $response"
+        } else {
+            decryptResponse(response)
+        }
+    }
+
+    // 公测报名状态查询（beta/query）
+    private fun sendBetaRequest(params: String): String {
+        val jvqParam = encryptToJvq(params)
+        val response = httpPost(BETA_URL, "jvq_param=$jvqParam")
+        return if (!response.startsWith("ACw") && !response.startsWith("ACo")) {
+            "[Error] $response"
+        } else {
+            decryptResponse(response)
+        }
+    }
+
+    // 内测报名状态查询（alpha/getAlphaState）
+    private fun sendAlphaRequest(params: String): String {
+        val jvqParam = encryptToJvq(params)
+        val response = httpPost(ALPHA_URL, "jvq_param=$jvqParam")
         return if (!response.startsWith("ACw") && !response.startsWith("ACo")) {
             "[Error] $response"
         } else {

--- a/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoOtaViewModel.kt
+++ b/app/android/src/main/kotlin/com/mytiantian/updater/vivo/VivoOtaViewModel.kt
@@ -34,6 +34,28 @@ class VivoOtaViewModel : ViewModel() {
         client = VivoOtaClient(ctx)
         loadHistory()
         initCrypto()
+        applyDefaultSelection()
+    }
+
+    private fun applyDefaultSelection() {
+        val defaultSeries = "X 系列"
+        val defaultModel = "vivo X200 Pro mini"
+        val devices = VivoDeviceDatabase.devicesOf(defaultSeries)
+        val index = devices.indexOfFirst { it.model == defaultModel }.coerceAtLeast(0)
+        val device = devices.getOrNull(index) ?: devices.firstOrNull() ?: return
+        val detectedType = detectDeviceType(defaultSeries)
+        _uiState.update {
+            it.copy(
+                selectedSeries = defaultSeries,
+                selectedModelIndex = index,
+                selectedModel = device.model,
+                selectedCodename = device.codename,
+                selectedModelSwVer = device.model_sw_ver,
+                deviceType = detectedType,
+                androidVersion = 15,
+                isCustomAndroidVersion = false
+            )
+        }
     }
 
     private fun initCrypto() {
@@ -109,8 +131,23 @@ class VivoOtaViewModel : ViewModel() {
     }
 
     fun updateSn(v: String) { _uiState.update { it.copy(sn = v) } }
+    fun updateQueryChannel(channel: String) {
+        _uiState.update {
+            // 尝鲜 / 公测 / 内测通道仅支持增量包，强制锁定为增量
+            if (channel != "NORMAL") {
+                it.copy(queryChannel = channel, isFullPackage = false)
+            } else {
+                it.copy(queryChannel = channel)
+            }
+        }
+    }
     fun updateDeviceType(type: String) { _uiState.update { it.copy(deviceType = type) } }
-    fun togglePackageType() { _uiState.update { it.copy(isFullPackage = !it.isFullPackage) } }
+    fun togglePackageType() {
+        _uiState.update {
+            // 尝鲜 / 公测 / 内测通道下禁止切换包类型，始终保持增量
+            if (it.queryChannel != "NORMAL") it else it.copy(isFullPackage = !it.isFullPackage)
+        }
+    }
     fun toggleManualMode() { _uiState.update { it.copy(manualMode = !it.manualMode) } }
     fun updateManualCodename(v: String) { _uiState.update { it.copy(manualCodename = v) } }
     fun updateManualModelSwVer(v: String) { _uiState.update { it.copy(manualModelSwVer = v) } }
@@ -195,7 +232,8 @@ class VivoOtaViewModel : ViewModel() {
                     androidVersion = state.androidVersion,
                     isPhone = state.deviceType == "phone",
                     isFull = state.isFullPackage,
-                    sn = state.sn
+                    sn = state.sn,
+                    channel = VivoOtaClient.QueryChannel.valueOf(state.queryChannel)
                 )
 
                 val hasUpdate = result.updateVersion.isNotEmpty() &&
@@ -241,7 +279,8 @@ class VivoOtaViewModel : ViewModel() {
             swVersion = swVersion,
             resultVersion = result.updateVersion,
             fileSize = result.fileSizeMb,
-            downloadUrl = result.downloadUrl
+            downloadUrl = result.downloadUrl,
+            channel = result.channel
         )
         val updated = (listOf(entry) + _uiState.value.history).take(20)
         _uiState.update { it.copy(history = updated) }
@@ -269,7 +308,8 @@ class VivoOtaViewModel : ViewModel() {
                         swVersion = o.getString("swVersion"),
                         resultVersion = o.optString("resultVersion", ""),
                         fileSize = o.optString("fileSize", ""),
-                        downloadUrl = o.optString("downloadUrl", "")
+                        downloadUrl = o.optString("downloadUrl", ""),
+                        channel = o.optString("channel", "NORMAL")
                     )
                 )
             }
@@ -291,6 +331,7 @@ class VivoOtaViewModel : ViewModel() {
                     put("resultVersion", e.resultVersion)
                     put("fileSize", e.fileSize)
                     put("downloadUrl", e.downloadUrl)
+                    put("channel", e.channel)
                 })
             }
             prefs.edit().putString("history", arr.toString()).apply()

--- a/app/android/src/main/res/values-hi/strings.xml
+++ b/app/android/src/main/res/values-hi/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">पैकेज प्रकार</string>
     <string name="pkg_full">पूर्ण पैकेज</string>
     <string name="pkg_incremental">वृद्धिशील</string>
+    <string name="pkg_locked_incremental">Trial / Beta / Alpha चैनल केवल वृद्धिशील पैकेज का समर्थन करते हैं</string>
 
     <!-- Query -->
     <string name="btn_query">OTA अपडेट खोजें</string>

--- a/app/android/src/main/res/values-in/strings.xml
+++ b/app/android/src/main/res/values-in/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">Jenis paket</string>
     <string name="pkg_full">Paket lengkap</string>
     <string name="pkg_incremental">Inkremental</string>
+    <string name="pkg_locked_incremental">Saluran Trial / Beta / Alpha hanya mendukung paket inkremental</string>
 
     <!-- Query -->
     <string name="btn_query">Cari Pembaruan OTA</string>

--- a/app/android/src/main/res/values-ja/strings.xml
+++ b/app/android/src/main/res/values-ja/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">パッケージタイプ</string>
     <string name="pkg_full">フルパッケージ</string>
     <string name="pkg_incremental">差分</string>
+    <string name="pkg_locked_incremental">Trial / Beta / Alpha チャンネルは差分パッケージのみ対応</string>
 
     <!-- Query -->
     <string name="btn_query">OTA 更新を検索</string>

--- a/app/android/src/main/res/values-ko/strings.xml
+++ b/app/android/src/main/res/values-ko/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">패키지 유형</string>
     <string name="pkg_full">전체 패키지</string>
     <string name="pkg_incremental">증분</string>
+    <string name="pkg_locked_incremental">Trial / Beta / Alpha 채널은 증분 패키지만 지원합니다</string>
 
     <!-- Query -->
     <string name="btn_query">OTA 업데이트 조회</string>

--- a/app/android/src/main/res/values-ru/strings.xml
+++ b/app/android/src/main/res/values-ru/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">Тип пакета</string>
     <string name="pkg_full">Полный пакет</string>
     <string name="pkg_incremental">Инкрементальный</string>
+    <string name="pkg_locked_incremental">В каналах Trial / Beta / Alpha поддерживаются только инкрементальные пакеты</string>
 
     <!-- Query -->
     <string name="btn_query">Запросить OTA-обновление</string>

--- a/app/android/src/main/res/values-th/strings.xml
+++ b/app/android/src/main/res/values-th/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">ประเภทแพ็กเกจ</string>
     <string name="pkg_full">แพ็กเกจเต็ม</string>
     <string name="pkg_incremental">แบบเพิ่มเติม</string>
+    <string name="pkg_locked_incremental">ช่องทาง Trial / Beta / Alpha รองรับเฉพาะแพ็กเกจแบบเพิ่มเติม</string>
 
     <!-- Query -->
     <string name="btn_query">ค้นหาอัปเดต OTA</string>

--- a/app/android/src/main/res/values-vi/strings.xml
+++ b/app/android/src/main/res/values-vi/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">Loại gói</string>
     <string name="pkg_full">Gói đầy đủ</string>
     <string name="pkg_incremental">Gói tăng dần</string>
+    <string name="pkg_locked_incremental">Kênh Trial / Beta / Alpha chỉ hỗ trợ gói tăng dần</string>
 
     <!-- Query -->
     <string name="btn_query">Tra cứu cập nhật OTA</string>

--- a/app/android/src/main/res/values-zh-rCN/strings.xml
+++ b/app/android/src/main/res/values-zh-rCN/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">包类型</string>
     <string name="pkg_full">完整包</string>
     <string name="pkg_incremental">增量包</string>
+    <string name="pkg_locked_incremental">尝鲜 / 公测 / 内测通道仅支持增量包</string>
 
     <!-- Query -->
     <string name="btn_query">查询 OTA 更新</string>

--- a/app/android/src/main/res/values-zh-rTW/strings.xml
+++ b/app/android/src/main/res/values-zh-rTW/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_package_type">包類型</string>
     <string name="pkg_full">完整包</string>
     <string name="pkg_incremental">增量包</string>
+    <string name="pkg_locked_incremental">嘗鮮 / 公測 / 內測通道僅支援增量包</string>
 
     <!-- Query -->
     <string name="btn_query">查詢 OTA 更新</string>

--- a/app/android/src/main/res/values/strings.xml
+++ b/app/android/src/main/res/values/strings.xml
@@ -27,6 +27,14 @@
     <string name="label_package_type">Package type</string>
     <string name="pkg_full">Full package</string>
     <string name="pkg_incremental">Incremental</string>
+    <string name="pkg_locked_incremental">Trial / Beta / Alpha channels only support incremental packages</string>
+
+    <!-- Query channel -->
+    <string name="label_query_channel">Query channel</string>
+    <string name="channel_normal">Official (Normal)</string>
+    <string name="channel_trial">Trial (尝鲜包)</string>
+    <string name="channel_beta">Beta (公测)</string>
+    <string name="channel_alpha">Alpha (内测)</string>
 
     <!-- Query -->
     <string name="btn_query">Query OTA Update</string>

--- a/buildSrc/src/main/kotlin/ProjectConfig.kt
+++ b/buildSrc/src/main/kotlin/ProjectConfig.kt
@@ -3,7 +3,7 @@ object ProjectConfig {
     const val APP_NAME = "vivo OTA Tracker"
     const val NAMESPACE = "com.mytiantian.updater"
     const val PACKAGE_NAME = "com.mytiantian.vivoupdater"
-    const val VERSION_NAME = "1.3.0"
+    const val VERSION_NAME = "1.3.1"
 
     object Android {
         const val TARGET_SDK = 37

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,217 @@
+# 构建指南与踩坑记录（Build Notes）
+
+本文档记录 VIVO-OTA-Tracker-Android 的构建方式与本机实测遇到的坑。
+
+## 1. 项目结构要点
+
+- KMP（Kotlin Multiplatform）项目，`app` 为共享代码，`app/android` 为 Android 应用模块。
+- 版本相关配置集中在 `buildSrc/src/main/kotlin/ProjectConfig.kt`。
+- Android 模块构建脚本：`app/android/build.gradle.kts`。
+
+## 2. 常用构建命令
+
+```bash
+# 构建 Debug APK（无需签名）
+./gradlew :app:android:assembleDebug
+
+# 构建 Release APK（需先配置签名，否则会失败）
+./gradlew :app:android:assembleRelease
+
+# 清理后重新构建（修复增量缓存损坏时必用）
+./gradlew :app:android:clean :app:android:assembleDebug
+```
+
+构建产物位置：
+- Debug：`app/android/build/outputs/apk/debug/vivo OTA Tracker-vX.Y.Z(N)-debug.apk`
+- Release：`app/android/build/outputs/apk/release/...`
+
+## 3. 踩坑记录
+
+### 坑 1：`BuildConfig` 报 "Unresolved reference"
+- **现象**：在 `androidMain` 业务代码里引用 `BuildConfig.*` 编译失败。
+- **原因**：AGP 8+ 默认关闭了 `buildConfig` 生成特性。
+- **解决**：在 `app/android/build.gradle.kts` 的 `android {}` 块中开启：
+  ```kotlin
+  buildFeatures { buildConfig = true }
+  ```
+
+### 坑 2：改了 `build.gradle.kts` 后报 `No file known for: classes.dex`
+- **现象**：`packageDebug` 阶段失败，`No file known for: classes.dex`。
+- **原因**：修改 `build.gradle.kts`（如开关 buildFeatures）使配置缓存/增量 dex 状态不一致。
+- **解决**：执行 `clean` 后重新构建即可：
+  ```bash
+  ./gradlew :app:android:clean :app:android:assembleDebug
+  ```
+
+### 坑 3：配置缓存与 build.gradle 改动冲突
+- **现象**：改 `build.gradle.kts` 后偶发缓存相关异常。
+- **缓解**：改动构建脚本时附加 `--no-configuration-cache`：
+  ```bash
+  ./gradlew :app:android:assembleDebug --no-configuration-cache
+  ```
+
+### 坑 4：业务代码不能直接引用 `buildSrc` 对象
+- **现象**：`import ProjectConfig` 报 "Unresolved reference"。
+- **原因**：`buildSrc` 只在 Gradle 配置阶段可见，不对应用运行时代码可见。
+- **解决**：需要把构建期常量传给业务代码时，用 `buildConfigField(...)` 注入到 `BuildConfig`，
+  而非直接 import。
+
+## 4. 本机实测结果
+
+- 环境：Windows / PowerShell 7 / Gradle 9.6.1（通过 `./gradlew`）。
+- 改动 `ProjectConfig.VERSION_NAME = "1.3.1"` 后，
+  `clean + assembleDebug` 构建成功，产物：
+  `vivo OTA Tracker-v1.3.1(6)-debug.apk`。
+- 一次完整 Debug 构建耗时约 3 分钟（首次/clean 后）。
+
+## 5. 全新环境搭建踩坑（Windows 实测）
+
+本机从零搭建时遇到的一系列环境类问题，按顺序解决后构建成功。
+
+### 环境要求
+- **JDK 25+**（项目 `mise.toml` 指定 `gradle = "9.6.1"`，Gradle daemon 需 JDK 25 运行）。
+- **Android SDK**：`compileSdk 37`（实际平台包为 `platforms;android-37.0`）、
+  `build-tools;37.0.0`、`platform-tools`。
+- 系统自带 Java 11 不够，需用 `mise install java@25` 安装 JDK 25。
+
+### 坑 5：Android SDK 组件版本号不是整数
+- **现象**：`sdkmanager "platforms;android-37"` 报 `Failed to find package`。
+- **原因**：API 37 的平台包在仓库里命名为 `platforms;android-37.0`（带 minor 版本）。
+- **解决**：安装 `platforms;android-37.0`、`build-tools;37.0.0`、`platform-tools`。
+
+### 坑 6：sdkmanager 直链文件名易错
+- `build-tools;37.0.0` 对应的官方直链 zip 是
+  **`build-tools_r37_windows.zip`**（注意是 `r37_windows`，下划线分隔，没有 `.0.0`）。
+  之前写成 `build-tools_r37-windows.zip` 会 404。
+- 平台包直链：`platform-37.0_r02.zip`；platform-tools：`platform-tools-latest-windows.zip`。
+- 国内镜像（清华大学）：`https://mirrors.tuna.tsinghua.edu.cn/Android/repository/`。
+
+### 坑 7：sdkmanager 在非 TTY 下不读 stdin 的 `y`
+- **现象**：`echo y | sdkmanager --licenses`、管道或 `Start-Process` 喂 `y` 都无法接受许可证，
+  构建报 `License for package Android SDK Platform 37.0 not accepted`。
+- **解决**：直接在 `Android SDK 根目录/licenses/` 下写入两个固定 hash 文件（等价于交互点 y）：
+  - `android-sdk-license` → `24333f8a63b6825ea9c5514f83c2829b004d1fee`
+  - `android-sdk-preview-license` → `84831b9409646a918e30573bab4c9c91346d8abd`
+  - 用 ASCII 无 BOM、无换行写入（`Set-Content -NoNewline -Encoding ascii`）。
+
+### 坑 8：Gradle 找不到 SDK 位置
+- **解决**：项目根目录 `local.properties` 写入 `sdk.dir=F:\\Android`，
+  或设置环境变量 `ANDROID_HOME=F:\Android`。
+
+### 坑 9：仓库源连不上（先确认是不是断网！）
+- **现象**：`settings.gradle.kts` 默认配阿里云镜像（`maven.aliyun.com`）。构建报
+  `Could not GET 'https://maven.aliyun.com/...' -> 不知道这样的主机。`
+- **重要**：本机实测阿里云镜像**本身可用**，该报错绝大多数是**电脑断网 / VPN 断开**导致，
+  不要因此盲目改仓库源。先检查网络再决定。
+- **注意**：Gradle 在某次会话中某仓库失败后会在本次会话**禁用该仓库**（日志 `Repository X is disabled due to earlier error`），
+  因此改完源或恢复网络后要加 `--refresh-dependencies` 或先 `./gradlew --stop` 杀掉 daemon 再构建。
+
+### 坑 10：Gradle daemon 缓存了错误的仓库/SDK 状态
+- 修改 `settings.gradle.kts` 或 SDK 目录后，建议先停 daemon 再构建：
+  ```bash
+  ./gradlew --stop
+  ./gradlew :app:android:assembleDebug --no-configuration-cache --refresh-dependencies
+  ```
+
+### 总结：从零到构建成功的最小步骤
+1. `mise install java@25`（或确保 JDK 25 在 PATH）。
+2. 下载 Android commandline-tools 到 `F:\Android\cmdline-tools\latest`，
+   用 JDK 25 的 java 运行 sdkmanager 安装 `platforms;android-37.0`、`build-tools;37.0.0`、`platform-tools`
+   （注意 sdkmanager.bat 需 `JAVA_HOME` 指向 JDK 25，否则回退系统 Java 报 class version 错）。
+3. 写 `F:\Android\licenses/` 下两个 license 文件。
+4. 项目根 `local.properties` 写 `sdk.dir=F:\\Android`。
+5. `settings.gradle.kts` 用阿里云镜像（`maven.aliyun.com`，本机实测可用，断网才会连不上）。
+6. `mise exec -- ./gradlew.bat :app:android:assembleDebug --no-configuration-cache` 构建。
+
+## 6. 升级版本的标准流程
+
+1. 改 `buildSrc/src/main/kotlin/ProjectConfig.kt` 的 `VERSION_NAME`。
+2. （可选）`git commit` 会让 versionCode 自动 +1。
+3. `./gradlew :app:android:clean :app:android:assembleDebug` 重新构建。
+4. 应用内关于页会自动显示新版本（通过 `BuildConfig.APP_VERSION_NAME`）。
+
+## 7. 生成发布签名密钥（release keystore）
+
+正式版 APK 必须签名才能装到非 root 设备。项目 `app/android/build.gradle.kts`
+已写好签名读取逻辑：优先读 `local.properties` 的 `KEYSTORE_PATH/KEYSTORE_PASS/KEY_ALIAS/KEY_PASSWORD`，
+其次读同名环境变量。
+
+### 生成 keystore
+用 JDK 自带 `keytool`（需 JDK 25，已在 PATH 或 `mise` 环境）：
+```bash
+keytool -genkeypair -v ^
+  -keystore "F:\learn-front\learn-hook\VIVO-OTA-Tracker-Android\release-key.jks" ^
+  -alias vivo_ota_tracker -keyalg RSA -keysize 2048 -validity 10000 ^
+  -storepass "VivoOta@2026" -keypass "VivoOta@2026" ^
+  -dname "CN=VivoOtaTracker, OU=Dev, O=MyTiAnTian, L=Unknown, ST=Unknown, C=CN"
+```
+- 有效期 10000 天（约 27 年），RSA 2048。
+- 本机实测生成成功，文件：`release-key.jks`，别名 `vivo_ota_tracker`。
+
+### 写入 local.properties
+```properties
+KEYSTORE_PATH=F:\learn-front\learn-hook\VIVO-OTA-Tracker-Android\release-key.jks
+KEYSTORE_PASS=VivoOta@2026
+KEY_ALIAS=vivo_ota_tracker
+KEY_PASSWORD=VivoOta@2026
+```
+之后 `build.gradle.kts` 会自动据此创建 `signingConfigs["release"]`（启用 V2+V3 签名），
+并挂到 `buildTypes.release` / `buildTypes.debug` 上。
+
+### 安全提醒（非常重要）
+- **`release-key.jks` 必须永久备份**（网盘 / 密码管理器），丢了就无法再更新已发布的 app。
+- `.gitignore` 已忽略 `local.properties`、`*.jks`、`*.keystore`，密钥**不会被提交进 git**，
+  确认无需额外处理。
+- 本机 `release-key.jks` 口令为 `VivoOta@2026`，属敏感信息，勿明文外传。
+
+## 8. 构建正式版（release）
+
+### 流程
+1. 确保已生成 keystore 并写入 `local.properties`（见第 7 节）。
+2. 确认 `buildSrc/.../ProjectConfig.kt` 的 `VERSION_NAME` 是要发的版本。
+3. 双击 `build-release.bat`，或命令行：
+   ```bash
+   .\gradlew.bat :app:android:clean :app:android:assembleRelease --no-configuration-cache
+   ```
+4. 产物：`app/android/build/outputs/apk/release/vivo OTA Tracker-vX.Y.Z(N)-release.apk`
+
+### 实测结果
+- 本机 `BUILD SUCCESSFUL in 3m 20s`，`versionCode=9`（git commit 数）。
+- release 开启 `minifyEnabled=true` + `shrinkResources=true`（R8 混淆 + 资源压缩），
+  比 debug 慢（约 3-5 分钟）。
+- 构建日志关键任务全跑通：`validateSigningRelease`、`writeReleaseSigningConfigVersions`、
+  `lintVitalRelease`、`minifyReleaseWithR8`、`packageRelease`。
+
+### 坑 11：PowerShell 下 `&` 会把构建放后台，日志被占用
+- **现象**：用 `gradlew ... > log.txt & echo EXIT` 时，PowerShell 的 `&` 是**后台作业**，
+  主进程立刻返回，且日志文件被后台 job 持续占用，后续 `Remove-Item` / 重跑会报
+  `being used by another process`。
+- **解决**：在 PowerShell 里用 `Start-Process -RedirectStandardOutput log.txt -Wait` 同步等待；
+  或先用 `Get-Job | Stop-Job` 清理残留后台作业再操作。
+- **不要**用 `cd /d` + `&&` 的 cmd 语法（PowerShell 不认 `cd /d`），改用 `Set-Location`。
+
+### 坑 12：断网导致 lint 工具下载失败（误判为仓库问题）
+- **现象**：`lintVitalAnalyzeRelease` 报 `Could not download intellij-core-32.2.1.jar from maven.aliyun.com`。
+- **根因**：当时电脑断网，并非阿里云镜像不可用。恢复网络后同配置构建成功。
+- **教训**：先确认网络，再决定是否改 `settings.gradle.kts` 仓库源（本项目用阿里云镜像正常）。
+- 临时绕过（不推荐，会失去 lint 检查）：在 `app/android/build.gradle.kts` 的
+  `android { lint { checkReleaseBuilds = false; abortOnError = false } }`。
+
+### 坑 13：release 版卡在"正在初始化加密引擎"
+- **现象**：debug 包正常，release 包安装后一直显示"正在初始化加密引擎"
+  （文案来自 `VivoApp.kt:251` 的 `crypto_init`，对应 `VivoCrypto.init()` 未完成 / `ready=false`）。
+- **根因**：R8 混淆 + 资源压缩会把 `com.vivo.seckeysdk.**`（native 加密引擎 `libvivoseckey.so`
+  的 JNI 封装层 `SDKCipherNative` / `NativeRequest` / `NativeResponse` 等）重命名或裁剪，
+  `SDKCipherNative.init()` 返回 `false`，UI 永远停在初始化。
+- **解决**：在 `app/android/proguard-rules-android.pro` 增加保留规则（已加）：
+  ```proguard
+  -keep class com.vivo.seckeysdk.** { *; }
+  -keep class com.vivo.seckeysdk.utils.** { *; }
+  -dontwarn com.vivo.seckeysdk.**
+  ```
+  （`com.mytiantian.updater.**` 本就在 `-keep` 里，无需再补。）
+- **验证方式**：本机重打 release 包 `BUILD SUCCESSFUL in 3m 35s`，`libvivoseckey.so` 仍正常打包；
+  **UI 是否真的不卡需在真机（vivo 设备）实测**（`adb logcat | grep VivoCrypto` 看
+  `Native init() => false` / `Using remote crypto server` 进一步定位）。
+- **注意**：`Unable to strip the following libraries: libvivoseckey.so` 是无害提示
+  （NDK 缺 strip 工具），不影响运行。

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,90 @@
+# 版本号体系（Versioning）
+
+本文档说明 VIVO-OTA-Tracker-Android 项目的版本号如何配置、流转，以及如何在应用内显示。
+
+## 1. 版本名（VERSION_NAME）的唯一定义处
+
+版本名集中定义在 `buildSrc/src/main/kotlin/ProjectConfig.kt`：
+
+```kotlin
+object ProjectConfig {
+    const val APP_NAME = "vivo OTA Tracker"
+    const val VERSION_NAME = "1.3.1"   // ← 版本名只改这一行
+    // ...
+}
+```
+
+`ProjectConfig` 是 `buildSrc` 模块里的 Kotlin 顶层 `object`（无 package 声明）：
+- 对所有模块的 **构建脚本（`.gradle.kts`）** 可见；
+- **不能直接被应用源码（Kotlin 业务代码）引用**。
+
+> ⚠️ 之前尝试在 `androidMain` 源码里直接 `import ProjectConfig` 会报 "Unresolved reference"，
+> 因为 `buildSrc` 的内容只对 Gradle 配置阶段可见，不对应用运行时代码可见。
+
+## 2. 版本号的自动生成（versionCode）
+
+`versionCode` 不是手填的，而是由 git commit 数量决定：
+
+`app/android/build.gradle.kts`
+```kotlin
+defaultConfig {
+    versionCode = getGitVersionCode()        // = git rev-list --count HEAD
+    versionName = ProjectConfig.VERSION_NAME
+}
+```
+
+`getGitVersionCode()` 在该文件顶部定义（执行 `git rev-list --count HEAD`）。
+因此每新增一个 commit，versionCode 自动 +1，无需手动维护。
+
+## 3. 版本名的三处流向
+
+```
+ProjectConfig.VERSION_NAME ("1.3.1")
+   │
+   ├─ defaultConfig.versionName
+   │         → 安装包的 versionName（系统「应用信息」里看到的版本）
+   │
+   ├─ buildConfigField("String", "APP_VERSION_NAME", "...")
+   │         → 注入到 BuildConfig.APP_VERSION_NAME（应用内代码读取）
+   │
+   └─ base.archivesName = APP_NAME + "-v" + VERSION_NAME + "(" + getGitVersionCode() + ")"
+             → 决定生成的 APK 文件名
+               例：vivo OTA Tracker-v1.3.1(6)-debug.apk
+```
+
+**结论**：改 `ProjectConfig.VERSION_NAME` 一处，会同时影响安装包版本名、APK 文件名、
+以及应用内显示的版本（见下一节），无需改多处。
+
+## 4. 在应用内显示版本号
+
+因为业务代码不能直接引用 `ProjectConfig`，采用「构建脚本注入 BuildConfig」的方式：
+
+`app/android/build.gradle.kts`
+```kotlin
+android {
+    buildFeatures { buildConfig = true }   // AGP 8+ 默认关闭，需手动开启
+    defaultConfig {
+        buildConfigField("String", "APP_VERSION_NAME", "\"${ProjectConfig.VERSION_NAME}\"")
+    }
+}
+```
+
+`AndroidAppContext.kt` 提供运行时读取（优先 PackageManager，回退 BuildConfig）：
+```kotlin
+val versionName: String   // 例："1.3.1"
+val versionCode: Long     // 例：6
+```
+
+关于页（`vivo/VivoApp.kt` 的 AboutDialog）显示：
+```kotlin
+val appVersion = "v" + AndroidAppContext.versionName
+Text(text = "$appVersion (${AndroidAppContext.versionCode})")  // 显示：v1.3.1 (6)
+```
+
+升级版本后 AboutDialog 会自动同步，不再需要像之前那样硬编码 `"v1.3.0"`。
+
+## 5. 版本命名约定
+
+- 遵循语义化版本 `x.y.z`（如 `1.3.1`）。
+- 仅修改 `ProjectConfig.VERSION_NAME` 字符串即可，其余自动同步。
+- versionCode 不要手动改，交给 git commit 数。

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+gradle = "9.6.1"


### PR DESCRIPTION
- 新增 ChannelCard 组件用于选择查询通道
- 实现尝鲜/公测/内测通道的 API 请求逻辑
- 添加通道数据模型和状态管理
- 支持不同通道的增量包锁定机制
- 在历史记录和结果显示中展示通道信息
- 适配多语言的通道名称和提示文本